### PR TITLE
Fix peft installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ conda create -n longlive python=3.10 -y
 conda activate longlive
 conda install nvidia/label/cuda-12.4.1::cuda
 conda install -c nvidia/label/cuda-12.4.1 cudatoolkit
-pip install torch==2.5.0 torchvision==0.20.0 torchaudio==2.5.0 --index-url https://download.pytorch.org/whl/cu124
+pip install torch==2.8.0 torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu128
 pip install -r requirements.txt
-pip install flash-attn==2.7.4.post1 --no-build-isolation
+pip install flash-attn --no-build-isolation
 ```
 
 ## Inference

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ onnxconverter_common
 flask
 flask-socketio
 torchao
+peft


### PR DESCRIPTION
f82901c341befd95166cfd4f54bd658dbb581edd adds peft to requirements.txt since it is required for running demo scripts now.

9f4731e21e8f55359d8a49504845cd61bce345ae updates README to use torch 2.8 and most recent flash-attn - a more recent version of torch is required to be compatible with peft (otherwise would get an error about missing torch.int1).