### PR TITLE
fix: use ImportError for relative import fallback

### DIFF
--- a/wan/utils/prompt_extend.py
+++ b/wan/utils/prompt_extend.py
@@ -335,7 +335,7 @@ class QwenPromptExpander(PromptExpander):
                                       Qwen2_5_VLForConditionalGeneration)
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except ImportError:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28


### PR DESCRIPTION
Replace bare `except:` with `except ImportError:` in `wan/utils/prompt_extend.py` for the qwen_vl_utils import fallback.