### PR TITLE
Adapt NVFP4 paths for i2v compatibility

### DIFF
--- a/configs/nvfp4/inference_i2v_nvfp4.yaml
+++ b/configs/nvfp4/inference_i2v_nvfp4.yaml
@@ -1,0 +1,94 @@
+# NVFP4 i2v inference with optional KV cache quantization and streaming VAE.
+# = configs/nvfp4/inference_nvfp4.yaml + i2v conditioning.
+# The first latent frame is encoded from the source image (provided by the
+# video dataset), kept clean during denoising, and the rollout continues from it.
+model_kwargs:
+  model_name: Wan2.2-TI2V-5B
+  timestep_shift: 5.0
+  num_frame_per_block: 8
+  local_attn_size: 32
+  sink_size: 8
+
+# Enable i2v: build the video dataset, encode the first frame to a clean latent,
+# and clamp it as the first-chunk conditioning during inference.
+i2v: true
+
+use_ema: false
+output_folder: videos/longlive2_i2v_nvfp4
+num_samples: 1
+save_latents_only: false
+save_with_index: true
+inference_iter: -1
+num_output_frames: 384
+merge_lora: false
+
+# i2v dataset / first-frame handling (read by MultiVideoConcatDataset in inference.py).
+allow_padding: false
+min_latent_frames: 0
+max_chunks_per_shot: 0
+uniform_prompt: false
+
+data:
+  # For i2v the data_path points at a video/image dataset; the first frame of
+  # each clip is used as the conditioning image.
+  data_path: /path/to/longlive2/inference_video_dataset
+  image_or_video_shape:
+  - 1
+  - 384
+  - 48
+  - 44
+  - 80
+
+inference:
+  sampling_steps: 4
+  # i2v conditioning: keep the first latent frame independent and clean.
+  independent_first_frame: true
+  # i2v training-time eval uses sink_size: 0; sink_size: 8 here matches the
+  # long-context streaming NVFP4 t2v setup. Tune as needed.
+  sink_size: 8
+  guidance_scale: 1.0
+  multi_shot_sink: true
+  multi_shot_rope_offset: 8
+  kv_quant: true
+  kv_quant_scale_rule: mse
+  kv_quant_backend: cuda
+  streaming_vae: false
+  async_vae: false
+  vae_type: wan # wan, mg_lightvae, mg_lightvae_v2
+  vae_device: "cuda:2"
+  negative_prompt: '色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'
+
+checkpoints:
+  generator_ckpt: /path/to/model_te.pt
+  # generator_ckpt: /path/to/model_4o6.pt # only set this if you are using FourOverSix (ckpt) for NVFP4
+
+model_quant: true
+model_quant_use_transformer_engine: true # only set this to true if you are using Transformer Engine (ckpt) for NVFP4; otherwise, set it to false (4o6)
+model_quant_te_inference_only: true
+model_quant_te_low_precision_weights: true
+model_quant_te_fallback_to_fouroversix: false # only set this to false if you are using FourOverSix (ckpt) for NVFP4; otherwise, set it to true (TE)
+model_quant_scale_rule: mse
+model_quant_activation_scale_rule: mse
+model_quant_weight_scale_rule: mse
+model_quant_gradient_scale_rule: mse
+
+torch_compile: auto
+torch_compile_min_samples: 2
+torch_compile_target: generator_model
+torch_compile_backend: inductor
+torch_compile_mode: max-autotune-no-cudagraphs
+torch_compile_fullgraph: false
+torch_compile_dynamic: false
+torch_compile_suppress_errors: true
+
+adapter:
+  type: lora
+  rank: 128
+  alpha: 128
+  dropout: 0.0
+  dtype: bfloat16
+  apply_to_critic: true
+  verbose: true
+
+logging:
+  seed: 0

--- a/configs/nvfp4/train_i2v_ar_nvfp4.yaml
+++ b/configs/nvfp4/train_i2v_ar_nvfp4.yaml
@@ -1,0 +1,101 @@
+# NVFP4 i2v AR teacher-forcing training.
+# = configs/train_i2v_ar.yaml + the NVFP4 quant infra from
+#   configs/nvfp4/train_ar_nvfp4.yaml.
+infra:
+  sequence_parallel_size: 4
+  sharding_strategy: hybrid_full
+  mixed_precision: true
+  gradient_checkpointing: true
+  vae_halo_latents: 28
+  generator_fsdp_wrap_strategy: size
+  text_encoder_fsdp_wrap_strategy: size
+  model_quant: true
+  model_quant_scale_rule: static_6
+  model_quant_activation_scale_rule: mse
+  model_quant_weight_scale_rule: static_6
+  model_quant_gradient_scale_rule: mse
+
+model_kwargs:
+  model_name: Wan2.2-TI2V-5B
+  timestep_shift: 5.0
+  num_frame_per_block: 8
+  local_attn_size: -1
+  sink_size: 8
+  t_scale: 1.0
+  rope_method: linear
+
+checkpoints:
+  generator_ckpt: /path/to/wan_or_ar_checkpoint.pt
+
+# I2V AR diffusion objective. The first latent frame is encoded from the
+# source image, kept clean, and masked out of the flow-matching loss.
+algorithm:
+  trainer: diffusion
+  i2v: true
+  causal: true
+  teacher_forcing: true
+  independent_first_frame: true
+  num_train_timestep: 1000
+  denoising_loss_type: flow
+
+training:
+  lr: 1.0e-05
+  weight_decay: 0.0
+  beta1: 0.0
+  beta2: 0.999
+  batch_size: 1
+  gradient_accumulation_steps: 1
+  ema_weight: 0.99
+  ema_start_step: 100
+  log_iters: 15
+  max_checkpoints: 20
+  max_iters: 600
+  gc_interval: 100
+  error_recycling:
+    enabled: true
+    num_buckets: 50
+    buffer_size_per_bucket: 500
+    buffer_warmup_iter: 50
+    context_inject_prob: 0.9
+    latent_inject_prob: 0.9
+    noise_inject_prob: 0.01
+    clean_prob: 0.2
+    clean_buffer_update_prob: 0.1
+    modulate_factor: 0.3
+    start_step: 0
+    replacement_strategy: random
+
+data:
+  data_path: /path/to/longlive2/train_video_dataset
+  eval_data_path: /path/to/longlive2/eval_video_dataset
+  image_or_video_shape:
+  - 1
+  - 96
+  - 48
+  - 44
+  - 80
+  load_raw_video: true
+
+inference:
+  sampling_steps: 50
+  sink_size: 0
+  multi_shot_sink: true
+  multi_shot_rope_offset: 8
+  guidance_scale: 3.0
+  independent_first_frame: true
+  use_relative_rope: false
+  inference_t_scale: 1.0
+  negative_prompt: '色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'
+
+evaluation:
+  interval: 1000
+  num_frames: 32
+  use_ema: true
+  val_batch_size: 1
+  save_latents_only: true
+
+logging:
+  seed: 0
+  wandb_key: null
+  wandb_entity: null
+  wandb_project: LongLive2-I2V-AR-NVFP4

--- a/configs/nvfp4/train_i2v_dmd_nvfp4_step4.yaml
+++ b/configs/nvfp4/train_i2v_dmd_nvfp4_step4.yaml
@@ -1,0 +1,142 @@
+# NVFP4 i2v DMD LoRA distillation, 4-step rollout.
+# = configs/train_i2v_dmd.yaml + the NVFP4 quant infra and 4-step denoising
+#   schedule from configs/nvfp4/train_dmd_nvfp4_step4.yaml.
+infra:
+  sharding_strategy: hybrid_full
+  mixed_precision: true
+  gradient_checkpointing: true
+  generator_fsdp_wrap_strategy: size
+  real_score_fsdp_wrap_strategy: size
+  fake_score_fsdp_wrap_strategy: size
+  text_encoder_fsdp_wrap_strategy: size
+  generator_quant: true
+  real_score_quant: true
+  fake_score_quant: false
+  real_score_quant_materialize: true
+  generator_quant_scale_rule: mse
+  generator_quant_activation_scale_rule: mse
+  generator_quant_weight_scale_rule: mse
+  generator_quant_gradient_scale_rule: mse
+  generator_quant_use_default_filtered_modules: false
+  real_score_quant_scale_rule: mse
+  real_score_quant_activation_scale_rule: mse
+  real_score_quant_weight_scale_rule: mse
+  real_score_quant_use_default_filtered_modules: false
+  generator_quant_filtered_modules: &nvfp4_filtered_modules
+  - text_embedding.0
+  - text_embedding.2
+  - patch_embedding
+  - time_projection.1
+  - time_embedding.0
+  - time_embedding.2
+  - head.head
+  - head.modulation
+  - re:.*norm_k$
+  - re:.*norm_q$
+  - re:.*norm1$
+  - re:.*norm2$
+  - re:.*norm3$
+  real_score_quant_filtered_modules: *nvfp4_filtered_modules
+
+model_kwargs:
+  model_name: Wan2.2-TI2V-5B
+  timestep_shift: 5.0
+  num_frame_per_block: 8
+  local_attn_size: 32
+  sink_size: 8
+
+# Optional initialization checkpoints. In practice, set generator_ckpt to the
+# i2v AR checkpoint used as the DMD student initialization.
+checkpoints:
+  generator_ckpt: null
+  real_score_ckpt: null
+  fake_score_ckpt: null
+
+# I2V DMD objective. Backward simulation uses the same first-chunk image
+# conditioning rule as i2v inference: the clean first latent is injected during
+# denoising and excluded from generator/critic losses.
+algorithm:
+  trainer: score_distillation
+  distribution_loss: dmd
+  i2v: true
+  all_causal: true
+  ts_schedule: false
+  num_train_timestep: 1000
+  denoising_loss_type: flow
+  warp_denoising_step: false
+  denoising_step_list: [1000, 946, 854, 681, 0]
+  teacher_forcing: false
+  backward_simulation: true
+  independent_first_frame: true
+  real_guidance_scale: 3.0
+  fake_guidance_scale: 0.0
+
+training:
+  lr: 1.0e-05
+  lr_critic: 2.0e-06
+  weight_decay: 0.0
+  beta1: 0.0
+  beta2: 0.999
+  beta1_critic: 0.0
+  beta2_critic: 0.999
+  batch_size: 1
+  gradient_accumulation_steps: 1
+  ema_weight: 0.99
+  ema_start_step: 200
+  log_iters: 50
+  max_checkpoints: 50
+  max_iters: 5000
+  gc_interval: 100
+  dfake_gen_update_ratio: 5
+  # Backward simulation samples a rollout length in [min_num_training_frames, num_training_frames].
+  # Setting both to 32 gives a fixed 32-latent DMD rollout.
+  min_num_training_frames: 32
+  num_training_frames: 32
+  # Keep this many tail latents for the DMD/critic losses after backward simulation.
+  # With a 32-latent rollout, 32 keeps the full generated window.
+  slice_last_frames: 32
+  chunks_per_shot: 2
+
+data:
+  data_path: /path/to/longlive2/train_video_dataset
+  eval_data_path: /path/to/longlive2/eval_video_dataset
+  image_or_video_shape:
+  - 1
+  - 32
+  - 48
+  - 44
+  - 80
+  load_raw_video: true
+
+# The distillation loop generates i2v trajectories, then computes DMD losses.
+inference:
+  sampling_steps: 4
+  sink_size: 0
+  multi_shot_sink: true
+  multi_shot_rope_offset: 8
+  independent_first_frame: true
+  negative_prompt: '色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'
+
+# Optional validation generation from the distilled model. Uses inference sampling/cache settings by default.
+evaluation:
+  interval: 99999999999
+  num_frames: 32
+  use_ema: false
+  val_batch_size: 1
+  save_latents_only: true
+
+# Presence of this section enables LoRA distillation; remove it for full fine-tuning.
+adapter:
+  type: lora
+  rank: 128
+  alpha: 128
+  dropout: 0.0
+  dtype: bfloat16
+  apply_to_critic: true
+  verbose: true
+
+logging:
+  seed: 0
+  wandb_key: null
+  wandb_entity: null
+  wandb_project: LongLive2-I2V-DMD-NVFP4

--- a/model/dmd.py
+++ b/model/dmd.py
@@ -219,7 +219,9 @@ class DMD(SelfForcingModel):
                 batch_size,
                 num_frame,
                 self.num_frame_per_block,
-                uniform_timestep=False
+                # t2v keeps the original NVFP4 behavior (one shared timestep across
+                # all frames); i2v uses per-block timesteps.
+                uniform_timestep=not getattr(self.args, "i2v", False)
             )
 
             # TODO:should we change it to `timestep = self.scheduler.timesteps[timestep]`?
@@ -414,7 +416,9 @@ class DMD(SelfForcingModel):
             batch_size,
             num_frame,
             self.num_frame_per_block,
-            uniform_timestep=False
+            # t2v keeps the original NVFP4 behavior (one shared timestep across
+            # all frames); i2v uses per-block timesteps.
+            uniform_timestep=not getattr(self.args, "i2v", False)
         )
 
         if self.timestep_shift > 1:


### PR DESCRIPTION
Gate the DMD timestep sampling on the i2v flag so t2v keeps the original NVFP4 behavior (one shared timestep across frames) while i2v uses per-block timesteps. Add NVFP4 i2v training (AR + DMD) and inference configs.