### PR TITLE
fix: os.cpu_count() may return None and crash build

### DIFF
--- a/fouroversix/setup.py
+++ b/fouroversix/setup.py
@@ -181,7 +181,7 @@ class NinjaBuildExtension(BuildExtension):
                 import psutil
 
                 # calculate the maximum allowed NUM_JOBS based on cores
-                max_num_jobs_cores = max(1, os.cpu_count() // 2)
+                max_num_jobs_cores = max(1, (os.cpu_count() or 1) // 2)
 
                 # calculate the maximum allowed NUM_JOBS based on free memory
                 free_memory_gb = psutil.virtual_memory().available / (


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/setup.py`: os.cpu_count() may return None and crash build.

## Changes
- `fouroversix/setup.py`: os.cpu_count() may return None and crash build.

## Details
```diff
--- a/fouroversix/setup.py
+++ b/fouroversix/setup.py
@@ -1,1 +1,1 @@
-                max_num_jobs_cores = max(1, os.cpu_count() // 2)
+                max_num_jobs_cores = max(1, (os.cpu_count() or 1) // 2)
```

## Tests

> Let me know if you want tests added for this fix or not.