### PR TITLE
fix: --batch-size option accepts non-integer floats

### DIFF
--- a/fouroversix/scripts/train/__main__.py
+++ b/fouroversix/scripts/train/__main__.py
@@ -172,7 +172,7 @@ class ModalTrainer:
 
 
 @click.command()
-@click.option("--batch-size", type=float, default=16)
+@click.option("--batch-size", type=int, default=16)
 @click.option("--checkpoint-interval", type=int, default=1000)
 @click.option("--checkpoint-keep-latest-k", type=int, default=0)
 @click.option("--checkpoint-load-step", type=int, default=-1)


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/scripts/train/__main__.py`: --batch-size option accepts non-integer floats.

## Changes
- `fouroversix/scripts/train/__main__.py`: --batch-size option accepts non-integer floats.

## Details
```diff
--- a/fouroversix/scripts/train/__main__.py
+++ b/fouroversix/scripts/train/__main__.py
@@ -1,1 +1,1 @@
-@click.option("--batch-size", type=float, default=16)
+@click.option("--batch-size", type=int, default=16)
```

## Tests

> Let me know if you want tests added for this fix or not.