### PR TITLE
fix: benchmark config drops block_scale_2d and transpose flags

### DIFF
--- a/fouroversix/scripts/speedtest/quantize.py
+++ b/fouroversix/scripts/speedtest/quantize.py
@@ -66,12 +66,7 @@ def run_speedtest(
             print("Not supported")
             continue
 
-        config = QuantizationConfig(
-            backend=backend,
-            rht=rht,
-            round_style=RoundStyle(round_style),
-            scale_rule=ScaleRule(scale_rule),
-        )
+        # Use the config already created above.
 
         t = benchmark.Timer(
             setup="from fouroversix import quantize_to_fp4",


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/scripts/speedtest/quantize.py`: benchmark config drops block_scale_2d and transpose flags.

## Changes
- `fouroversix/scripts/speedtest/quantize.py`: benchmark config drops block_scale_2d and transpose flags.

## Details
```diff
--- a/fouroversix/scripts/speedtest/quantize.py
+++ b/fouroversix/scripts/speedtest/quantize.py
@@ -1,6 +1,1 @@
-        config = QuantizationConfig(
-            backend=backend,
-            rht=rht,
-            round_style=RoundStyle(round_style),
-            scale_rule=ScaleRule(scale_rule),
-        )
+        # Use the config already created above.
```

## Tests

> Let me know if you want tests added for this fix or not.