### PR TITLE
fix: avoid NameError when submodule is missing from .gitmodules

### DIFF
--- a/fouroversix/scripts/resources.py
+++ b/fouroversix/scripts/resources.py
@@ -91,10 +91,15 @@ class Submodule(str, Enum):
         config = configparser.ConfigParser()
         config.read_string(gitmodules_contents)
 
+        url = None
         for section in config.sections():
             if config[section]["path"] == self.get_local_path():
                 url = config[section]["url"]
                 break
+
+        if url is None:
+            msg = f"Submodule {self.get_local_path()} not found in .gitmodules"
+            raise ValueError(msg)
 
         if url.startswith("https://"):
             return url


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/scripts/resources.py`: avoid NameError when submodule is missing from .gitmodules.

## Changes
- `fouroversix/scripts/resources.py`: avoid NameError when submodule is missing from .gitmodules.

## Details
```diff
--- a/fouroversix/scripts/resources.py
+++ b/fouroversix/scripts/resources.py
@@ -1,10 +1,15 @@
-        for section in config.sections():
-            if config[section]["path"] == self.get_local_path():
-                url = config[section]["url"]
-                break
-
-        if url.startswith("https://"):
-            return url
-
-        msg = f"Unsupported remote URL format: {url}"
-        raise ValueError(msg)
+        url = None
+        for section in config.sections():
+            if config[section]["path"] == self.get_local_path():
+                url = config[section]["url"]
+                break
+
+        if url is None:
+            msg = f"Submodule {self.get_local_path()} not found in .gitmodules"
+            raise ValueError(msg)
+
+        if url.startswith("https://"):
+            return url
+
+        msg = f"Unsupported remote URL format: {url}"
+        raise ValueError(msg)
```

## Tests

> Let me know if you want tests added for this fix or not.