### PR TITLE
fix: RTN cache path built from int hash

### DIFF
--- a/fouroversix/scripts/ptq/evaluators/rtn.py
+++ b/fouroversix/scripts/ptq/evaluators/rtn.py
@@ -44,7 +44,7 @@ class RTNEvaluatorImpl(PTQEvaluator):
         """Quantize a model using round-to-nearest quantization."""
 
         model_save_path = (
-            save_path / "rtn" / model_name / quantization_config.__hash__()
+            save_path / "rtn" / model_name / str(quantization_config.__hash__())
         )
 
         if not model_save_path.exists():


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/scripts/ptq/evaluators/rtn.py`: RTN cache path built from int hash.

## Changes
- `fouroversix/scripts/ptq/evaluators/rtn.py`: RTN cache path built from int hash.

## Details
```diff
--- a/fouroversix/scripts/ptq/evaluators/rtn.py
+++ b/fouroversix/scripts/ptq/evaluators/rtn.py
@@ -1,3 +1,3 @@
-        model_save_path = (
-            save_path / "rtn" / model_name / quantization_config.__hash__()
-        )
+        model_save_path = (
+            save_path / "rtn" / model_name / str(quantization_config.__hash__())
+        )
```

## Tests

> Let me know if you want tests added for this fix or not.