### PR TITLE
fix: GPTQ cache path built from int hash

### DIFF
--- a/fouroversix/scripts/ptq/evaluators/gptq.py
+++ b/fouroversix/scripts/ptq/evaluators/gptq.py
@@ -64,7 +64,7 @@ class GPTQEvaluator(PTQEvaluator):
         from model_quant import main
         from transformers import AutoModelForCausalLM
 
-        save_path = save_path / "gptq" / model_name / quantization_config.__hash__()
+        save_path = save_path / "gptq" / model_name / str(quantization_config.__hash__())
 
         if not save_path.exists():
             sys.argv = [


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/scripts/ptq/evaluators/gptq.py`: GPTQ cache path built from int hash.

## Changes
- `fouroversix/scripts/ptq/evaluators/gptq.py`: GPTQ cache path built from int hash.

## Details
```diff
--- a/fouroversix/scripts/ptq/evaluators/gptq.py
+++ b/fouroversix/scripts/ptq/evaluators/gptq.py
@@ -1,1 +1,1 @@
-        save_path = save_path / "gptq" / model_name / quantization_config.__hash__()
+        save_path = save_path / "gptq" / model_name / str(quantization_config.__hash__())
```

## Tests

> Let me know if you want tests added for this fix or not.