### PR TITLE
fix: inspect_ai Model passed API class not instance

### DIFF
--- a/fouroversix/scripts/ptq/evaluators/evaluator.py
+++ b/fouroversix/scripts/ptq/evaluators/evaluator.py
@@ -158,12 +158,12 @@ class PTQEvaluator(ABC):
                 from inspect_ai.model import Model
                 from inspect_ai.model._generate_config import GenerateConfig
 
-                from .utils import local_hf
+                from .utils import LocalHuggingFaceAPI
 
                 config = GenerateConfig()
                 full_results = inspect_ai.eval(
                     tasks=tasks,
-                    model=Model(local_hf(model_name, model, config), config, None),
+                    model=Model(LocalHuggingFaceAPI(model_name, model, config), config, None),
                     limit=limit,
                     log_dir=(save_path / "inspect_ai_logs").as_posix(),
                     display="none",


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/scripts/ptq/evaluators/evaluator.py`: inspect_ai Model passed API class not instance.

## Changes
- `fouroversix/scripts/ptq/evaluators/evaluator.py`: inspect_ai Model passed API class not instance.

## Details
```diff
--- a/fouroversix/scripts/ptq/evaluators/evaluator.py
+++ b/fouroversix/scripts/ptq/evaluators/evaluator.py
@@ -1,6 +1,6 @@
-                from .utils import local_hf
-
-                config = GenerateConfig()
-                full_results = inspect_ai.eval(
-                    tasks=tasks,
-                    model=Model(local_hf(model_name, model, config), config, None),
+                from .utils import LocalHuggingFaceAPI
+
+                config = GenerateConfig()
+                full_results = inspect_ai.eval(
+                    tasks=tasks,
+                    model=Model(LocalHuggingFaceAPI(model_name, model, config), config, None),
```

## Tests

> Let me know if you want tests added for this fix or not.