### PR TITLE
fix: deprecated ::set-output syntax breaks release outputs

### DIFF
--- a/fouroversix/.github/workflows/publish.yml
+++ b/fouroversix/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get the tag version
         id: extract_branch
-        run: echo ::set-output name=branch::${GITHUB_REF#refs/tags/}
+        run: echo "branch=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Create Release
         id: create_release


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/.github/workflows/publish.yml`: deprecated ::set-output syntax breaks release outputs.

## Changes
- `fouroversix/.github/workflows/publish.yml`: deprecated ::set-output syntax breaks release outputs.

## Details
```diff
--- a/fouroversix/.github/workflows/publish.yml
+++ b/fouroversix/.github/workflows/publish.yml
@@ -1,2 +1,2 @@
-        run: echo ::set-output name=branch::${GITHUB_REF#refs/tags/}
-        shell: bash
+        run: echo "branch=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        shell: bash
```

## Tests

> Let me know if you want tests added for this fix or not.