### PR TITLE
fix: release asset content type uses wildcard MIME type

### DIFF
--- a/fouroversix/.github/workflows/_build.yml
+++ b/fouroversix/.github/workflows/_build.yml
@@ -212,4 +212,4 @@ jobs:
           upload_url: ${{ steps.get_current_release.outputs.upload_url }}
           asset_path: ./dist/${{env.wheel_name}}
           asset_name: ${{env.wheel_name}}
-          asset_content_type: application/*
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/.github/workflows/_build.yml`: release asset content type uses wildcard MIME type.

## Changes
- `fouroversix/.github/workflows/_build.yml`: release asset content type uses wildcard MIME type.

## Details
```diff
--- a/fouroversix/.github/workflows/_build.yml
+++ b/fouroversix/.github/workflows/_build.yml
@@ -1,1 +1,1 @@
-          asset_content_type: application/*
+          asset_content_type: application/octet-stream
```

## Tests

> Let me know if you want tests added for this fix or not.