### PR TITLE
fix: nightly Triton URL uses invalid multi-tag platform slug

### DIFF
--- a/fouroversix/.github/workflows/_build.yml
+++ b/fouroversix/.github/workflows/_build.yml
@@ -98,9 +98,9 @@ jobs:
           pip install typing-extensions==4.12.2
           # detect if we're on ARM
           if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
-              PLAT=linux_aarch64
+              PLAT=manylinux_2_28_aarch64
           else
-              PLAT=manylinux_2_27_x86_64.manylinux_2_28_x86_64
+              PLAT=manylinux_2_28_x86_64
           fi
           echo "PLAT=$PLAT" >> $GITHUB_ENV
           if [[ ${{ inputs.torch-version }} == *"dev"* ]]; then


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/.github/workflows/_build.yml`: nightly Triton URL uses invalid multi-tag platform slug.

## Changes
- `fouroversix/.github/workflows/_build.yml`: nightly Triton URL uses invalid multi-tag platform slug.

## Details
```diff
--- a/fouroversix/.github/workflows/_build.yml
+++ b/fouroversix/.github/workflows/_build.yml
@@ -1,5 +1,5 @@
-          if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
-              PLAT=linux_aarch64
-          else
-              PLAT=manylinux_2_27_x86_64.manylinux_2_28_x86_64
-          fi
+          if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+              PLAT=manylinux_2_28_aarch64
+          else
+              PLAT=manylinux_2_28_x86_64
+          fi
```

## Tests

> Let me know if you want tests added for this fix or not.