### PR TITLE
fix: get-release step runs when upload-to-release is false

### DIFF
--- a/fouroversix/.github/workflows/_build.yml
+++ b/fouroversix/.github/workflows/_build.yml
@@ -195,6 +195,7 @@ jobs:
           ls dist
 
       - name: Get Release with tag
+        if: inputs.upload-to-release
         id: get_current_release
         uses: joutvhu/get-release@v1
         with:


### PR DESCRIPTION
This PR addresses the following issue in `fouroversix/.github/workflows/_build.yml`: get-release step runs when upload-to-release is false.

## Changes
- `fouroversix/.github/workflows/_build.yml`: get-release step runs when upload-to-release is false.

## Details
```diff
--- a/fouroversix/.github/workflows/_build.yml
+++ b/fouroversix/.github/workflows/_build.yml
@@ -1,7 +1,8 @@
-      - name: Get Release with tag
-        id: get_current_release
-        uses: joutvhu/get-release@v1
-        with:
-          tag_name: ${{ inputs.release-version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Release with tag
+        if: inputs.upload-to-release
+        id: get_current_release
+        uses: joutvhu/get-release@v1
+        with:
+          tag_name: ${{ inputs.release-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

## Tests

> Let me know if you want tests added for this fix or not.