### PR TITLE
fix: missing multi_shot_sink flag disables rope offset

### DIFF
--- a/configs/train_i2v_dmd.yaml
+++ b/configs/train_i2v_dmd.yaml
@@ -77,6 +77,7 @@ data:
 inference:
   sampling_steps: 4
   sink_size: 0
+  multi_shot_sink: true
   multi_shot_rope_offset: 8
   independent_first_frame: true
 


### PR DESCRIPTION
This PR addresses the following issue in `configs/train_i2v_dmd.yaml`: missing multi_shot_sink flag disables rope offset.

## Changes
- `configs/train_i2v_dmd.yaml`: missing multi_shot_sink flag disables rope offset.

## Details
```diff
--- a/configs/train_i2v_dmd.yaml
+++ b/configs/train_i2v_dmd.yaml
@@ -1,4 +1,5 @@
-  sampling_steps: 4
-  sink_size: 0
-  multi_shot_rope_offset: 8
-  independent_first_frame: true
+  sampling_steps: 4
+  sink_size: 0
+  multi_shot_sink: true
+  multi_shot_rope_offset: 8
+  independent_first_frame: true
```

## Tests

> Let me know if you want tests added for this fix or not.