### PR TITLE
fix: missing multi_shot_sink flag disables rope offset

### DIFF
--- a/configs/train_dmd.yaml
+++ b/configs/train_dmd.yaml
@@ -75,6 +75,7 @@ data:
 inference:
   sampling_steps: 4
   sink_size: 0
+  multi_shot_sink: true
   multi_shot_rope_offset: 8
 
 # Optional validation generation from the distilled model. Uses inference sampling/cache settings by default.


### PR DESCRIPTION
This PR addresses the following issue in `configs/train_dmd.yaml`: missing multi_shot_sink flag disables rope offset.

## Changes
- `configs/train_dmd.yaml`: missing multi_shot_sink flag disables rope offset.

## Details
```diff
--- a/configs/train_dmd.yaml
+++ b/configs/train_dmd.yaml
@@ -1,3 +1,4 @@
-  sampling_steps: 4
-  sink_size: 0
-  multi_shot_rope_offset: 8
+  sampling_steps: 4
+  sink_size: 0
+  multi_shot_sink: true
+  multi_shot_rope_offset: 8
```

## Tests

> Let me know if you want tests added for this fix or not.